### PR TITLE
Link to ~/.local/share/fonts instead of ~/.fonts

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ $ brew install font-inconsolata --HEAD
 If you're using major distributions, just type;
 
 ```
-$ ln -s /home/linuxbrew/.linuxbrew/share/fonts ~/.fonts
+$ ln -s /home/linuxbrew/.linuxbrew/share/fonts ~/.local/share/fonts
 $ fc-cache -fv
 ```
 


### PR DESCRIPTION
`~/.fonts` has been replaced by `~/.local/share/fonts` as described in https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html