### PR TITLE
Replace calls to version properties in font strings

### DIFF
--- a/cask2formula
+++ b/cask2formula
@@ -2,6 +2,18 @@
 
 require "parslet"
 
+def replace_cask_version_properties(input_string)
+    input_string
+      .gsub(".no_dots", '.gsub(".", "")')
+      .gsub(".dots_to_underscores", '.gsub(".", "_")')
+      .gsub(".dots_to_slashes", '.gsub(".", "/")')
+      .gsub(".dots_to_hyphens", '.gsub(".", "-")')
+      .gsub(".major", '.sub(/\\..*/, "")')
+      .gsub(".before_comma", '.sub(/,.*/, "")')
+      .gsub(".after_comma", '.sub(/.*,/, "")')
+      .gsub("version.", "version.to_s.")
+end
+
 class CaskParser < Parslet::Parser
     rule(:space) { 
         match("[ \t\n]").repeat
@@ -62,7 +74,7 @@ class CaskTransform < Parslet::Transform
         left + " " + right
     }
     rule(:font   => simple(:font)) {
-      "(share/\"fonts\").install #{font.sub(/"(.*\/)/, '"../\1')}"
+      "(share/\"fonts\").install #{replace_cask_version_properties(font.sub(/"(.*\/)/, '"../\1'))}"
     }
     rule(:name   => simple(:name),
          :before => sequence(:before),
@@ -106,15 +118,7 @@ class CaskTransform < Parslet::Transform
             @@no_check = false
             "head #{arguments.join(", ")}"
         else
-            command + " " + arguments.join(", ").to_s
-            .gsub(".no_dots", '.gsub(".", "")')
-            .gsub(".dots_to_underscores", '.gsub(".", "_")')
-            .gsub(".dots_to_slashes", '.gsub(".", "/")')
-            .gsub(".dots_to_hyphens", '.gsub(".", "-")')
-            .gsub(".major", '.sub(/\\..*/, "")')
-            .gsub(".before_comma", '.sub(/,.*/, "")')
-            .gsub(".after_comma", '.sub(/.*,/, "")')
-            .gsub("version.", "version.to_s.")
+            command + " " + replace_cask_version_properties(arguments.join(", ").to_s)
         end
     }
 end


### PR DESCRIPTION
Fixes #9.

The `cask2formula` script didn't translate calls to `version` methods if they appeared inside a `font` string.

This PR extracts the `version` conversion used for unmatched commands (in `cask2formula`), and uses it on `font` commands as well.

Here's the change to the Fira Mono font formula, as an example (a number of formulae get changes):

```diff
class FontFiraMono < Formula
  version "3.206,4.202"
  sha256 "d86269657387f144d77ba12011124f30f423f70672e1576dc16f918bb16ddfe4"
  url "https://github.com/mozilla/Fira/archive/#{version.to_s.sub(/.*,/, "")}.tar.gz"
  desc "Fira Mono"
  homepage "https://mozilla.github.io/Fira/"
  def install
-    (share/"fonts").install "../Fira-#{version.after_comma}/otf/FiraMono-Bold.otf"
-    (share/"fonts").install "../Fira-#{version.after_comma}/otf/FiraMono-Medium.otf"
-    (share/"fonts").install "../Fira-#{version.after_comma}/otf/FiraMono-Regular.otf"
+    (share/"fonts").install "../Fira-#{version.to_s.sub(/.*,/, "")}/otf/FiraMono-Bold.otf"
+    (share/"fonts").install "../Fira-#{version.to_s.sub(/.*,/, "")}/otf/FiraMono-Medium.otf"
+    (share/"fonts").install "../Fira-#{version.to_s.sub(/.*,/, "")}/otf/FiraMono-Regular.otf"
  end
  test do
  end
end
```