### PR TITLE
Add .caskignore

### DIFF
--- a/.caskignore
+++ b/.caskignore
@@ -1,1 +1,1 @@
-**/font-lisutzimu.rb
+./**/font-lisutzimu.rb

--- a/.caskignore
+++ b/.caskignore
@@ -1,0 +1,1 @@
+**/font-lisutzimu.rb

--- a/.caskignore
+++ b/.caskignore
@@ -1,1 +1,3 @@
 ./**/font-lisutzimu.rb
+./**/font-meltho.rb
+

--- a/Formula/font-meltho.rb
+++ b/Formula/font-meltho.rb
@@ -1,7 +1,7 @@
 class FontMeltho < Formula
   version "1.21,2018.06"
   sha256 "a22e61b0a48ac6c3e8bbc79d8f4dafcbd7ddb9572cf63b50478b9889cfbfdac4"
-  url "https://bethmardutho.org/wp-content/uploads/#{version.to_s.sub(/.*,/, "").sub(/\..*/, "")}/#{version.to_s.sub(/.*,/, "").minor}/melthofonts-1.zip"
+  url "https://bethmardutho.org/wp-content/uploads/#{version.to_s.sub(/.*,/, "").sub(/\..*/, "")}/#{version.to_s.sub(/.*,.*\./, "")}/melthofonts-1.zip"
   desc "Meltho Fonts"
   homepage "http://bethmardutho.org/syriacmac/"
   def install

--- a/Formula/font-redhat.rb
+++ b/Formula/font-redhat.rb
@@ -1,0 +1,25 @@
+class FontRedhat < Formula
+  version "2.2.0"
+  sha256 "5c1bb9cc53343b892bd5cfa32ba6ed1d3bf61c297ec43f326a0680887b2d8d5c"
+  url "https://github.com/RedHatOfficial/RedHatFont/archive/#{version}.tar.gz"
+  desc "Red Hat"
+  homepage "https://github.com/RedHatOfficial/RedHatFont/"
+  def install
+    (share/"fonts").install "../RedHatFont-#{version}/OTF/RedHatDisplay-Black.otf"
+    (share/"fonts").install "../RedHatFont-#{version}/OTF/RedHatDisplay-BlackItalic.otf"
+    (share/"fonts").install "../RedHatFont-#{version}/OTF/RedHatDisplay-Bold.otf"
+    (share/"fonts").install "../RedHatFont-#{version}/OTF/RedHatDisplay-BoldItalic.otf"
+    (share/"fonts").install "../RedHatFont-#{version}/OTF/RedHatDisplay-Italic.otf"
+    (share/"fonts").install "../RedHatFont-#{version}/OTF/RedHatDisplay-Medium.otf"
+    (share/"fonts").install "../RedHatFont-#{version}/OTF/RedHatDisplay-MediumItalic.otf"
+    (share/"fonts").install "../RedHatFont-#{version}/OTF/RedHatDisplay-Regular.otf"
+    (share/"fonts").install "../RedHatFont-#{version}/OTF/RedHatText-Bold.otf"
+    (share/"fonts").install "../RedHatFont-#{version}/OTF/RedHatText-BoldItalic.otf"
+    (share/"fonts").install "../RedHatFont-#{version}/OTF/RedHatText-Italic.otf"
+    (share/"fonts").install "../RedHatFont-#{version}/OTF/RedHatText-Medium.otf"
+    (share/"fonts").install "../RedHatFont-#{version}/OTF/RedHatText-MediumItalic.otf"
+    (share/"fonts").install "../RedHatFont-#{version}/OTF/RedHatText-Regular.otf"
+  end
+  test do
+  end
+end

--- a/README.md
+++ b/README.md
@@ -28,10 +28,18 @@ $ fc-cache -fv
 
 Then you can use the new font installed by `brew`.
 
-## Submitting a Font Cask and Bugs
+## Development
+
+### Submitting a Font Cask and Bugs
 
 When you change file in [the upstream repository](https://github.com/homebrew/homebrew-cask-fonts/),
 I follow your changes, because this repository automatically imports new casks from the repository with a bot program.
+
+### Skipping translations by `.caskignore`
+
+Some casks incompatible with formula-way.
+Then `cask2formula` will skip translation by `.caskignore`.
+`.caskignore` is written in Ruby's [`fnmatch` syntax](https://docs.ruby-lang.org/en/2.6.0/File.html#method-c-fnmatch).
 
 ## Font Licenses
 

--- a/cask2formula
+++ b/cask2formula
@@ -127,13 +127,16 @@ class CaskConverter
     def convert
       transform = CaskTransform.new
       parser = CaskParser.new
-      Dir.glob('./homebrew-cask-fonts/Casks/*.rb').select{|file| file !~ /font-lisutzimu/}.each do |cask|
+      ignores = IO.readlines('.caskignore', chomp: true)
+      Dir.glob('./homebrew-cask-fonts/Casks/*.rb').select{|file|
+        ignores.all? { |ignore| !File.fnmatch(ignore, file) }
+      }.each{|cask|
         recipe = File.read(cask)
         recipe = transform.apply(parser.parse(recipe))
         formula = cask.sub(%r{homebrew-cask-fonts/Casks}, 'Formula')
         File.write(formula, recipe)
         p "#{cask} -> #{formula}"
-      end
+      }
     end
 
     def commit


### PR DESCRIPTION
This pull request offers to add `.caskignore` file since some casks are not written in the formula-way, like #11 . `cask2formula` skips translating the casks by `.caskignore` . The file follows Ruby's fnmatch syntax. CC: @sjackman, @rafifos