### PR TITLE
docs: avoid creating symlink inside symlink to fonts

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ $ brew install font-inconsolata --HEAD
 If you're using major distributions in a single-user installation, run:
 
 ```
-$ ln -s /home/linuxbrew/.linuxbrew/share/fonts ~/.local/share/fonts
+$ ln --symbolic --no-dereference /home/linuxbrew/.linuxbrew/share/fonts ~/.local/share/fonts
 $ fc-cache -fv
 ```
 


### PR DESCRIPTION
A simple `ln -s TARGET LINK_NAME` will by default create a symlink with the name `LINK_NAME` if `LINK_NAME` is a file or will create a symlink inside `LINK_NAME` if `LINK_NAME` is a directory. For example:

```sh
$ ln -sv /home/linuxbrew/.linuxbrew/share/fonts ~/.local/share/fonts
'/home/my-user/.local/share/fonts' -> '/home/linuxbrew/.linuxbrew/share/fonts'

$ ln -sv /home/linuxbrew/.linuxbrew/share/fonts ~/.local/share/fonts
'/home/my-user/.local/share/fonts/fonts' -> '/home/linuxbrew/.linuxbrew/share/fonts'

$ ln -sv /home/linuxbrew/.linuxbrew/share/fonts ~/.local/share/fonts
ln: failed to create symbolic link '/home/my-user/.local/share/fonts/fonts': File exists
```

The parameter `--no-dereference` will tread the LINK_NAME as a file avoiding such problem:

```
$ ln --verbose --symbolic --no-dereference /home/linuxbrew/.linuxbrew/share/fonts ~/.local/share/fonts
'/home/my-user/.local/share/fonts' -> '/home/linuxbrew/.linuxbrew/share/fonts'

$ ln --verbose --symbolic --no-dereference /home/linuxbrew/.linuxbrew/share/fonts ~/.local/share/fonts
ln: failed to create symbolic link '/home/my-user/.local/share/fonts': File exists
```
