### PR TITLE
Allows ! in cask commands, e.g. deprecate!

### DIFF
--- a/cask2formula
+++ b/cask2formula
@@ -32,7 +32,7 @@ class CaskParser < Parslet::Parser
         str("'"))).as(:string)
     }
     rule(:word) {
-        match("[0-9a-zA-Z_]").repeat(1)
+        match("[0-9a-zA-Z_!]").repeat(1)
     }
     rule(:keyword) {
         (str(":") >> word).as(:keyword)


### PR DESCRIPTION
https://github.com/Homebrew/brew/pull/16292 enabled `deprecate!` and `disable!`, which the parser here can't handle because it can't handle `!` in method names.
