### PR TITLE
Run scheduled job only on main repo

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 jobs:
   build:
-    if: ( github.event.schedule && github.repository == 'homebrew/homebrew-linux-fonts' ) || ! github.event.schedule
+    if: github.repository_owner == 'Homebrew' || !github.event.schedule
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -5,6 +5,7 @@ on:
   workflow_dispatch:
 jobs:
   build:
+    if: ( github.event.schedule && github.repository == 'homebrew/homebrew-linux-fonts' ) || ! github.event.schedule
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Limits the scheduled job to run only on the main repo. Forks can still run through workflow dispatch or manual runs.