### PR TITLE
Inter 4.0. Fix `font-inter.rb`

### DIFF
--- a/Formula/font-inter.rb
+++ b/Formula/font-inter.rb
@@ -1,14 +1,14 @@
 class FontInter < Formula
-  version "4.0"
-  sha256 "ff970a5d4561a04f102a7cb781adbd6ac4e9b6c460914c7a101f15acb7f7d1a4"
-  url "https://github.com/rsms/inter/releases/download/v#{version}/Inter-#{version}.zip", verified: "github.com/rsms/inter/"
-  desc "Inter"
   desc "Variable font designed for display"
   homepage "https://rsms.me/inter/"
+  url "https://github.com/rsms/inter/releases/download/v#{version}/Inter-#{version}.zip", verified: "github.com/rsms/inter/"
+  version "4.0"
+  sha256 "ff970a5d4561a04f102a7cb781adbd6ac4e9b6c460914c7a101f15acb7f7d1a4"
+  name "Inter"
   def install
-    parent = File.dirname(Dir.pwd) != (ENV['HOMEBREW_TEMP'] || '/tmp') ?  '../' : ''
-    (share/"fonts").install "ofl/intertight/" + "InterVariable-Italic.ttf"
-    (share/"fonts").install "ofl/intertight/" + "InterVariable.ttf"
+    parent = (File.dirname(Dir.pwd) == (ENV["HOMEBREW_TEMP"] || "/tmp")) ? "" : "../"
+    (share/"fonts").install "#{parent}InterVariable-Italic.ttf"
+    (share/"fonts").install "#{parent}InterVariable.ttf"
     (share/"fonts").install "#{parent}extras/otf/Inter-Black.otf"
     (share/"fonts").install "#{parent}extras/otf/Inter-BlackItalic.otf"
     (share/"fonts").install "#{parent}extras/otf/Inter-Bold.otf"


### PR DESCRIPTION
For some reason for `InterVariable.ttf` and `InterVariable-Italic.ttf` have been prefixed with a wrong path.
This commit fixes that.

- [ ] `brew cask audit --download {{cask_file}}` is error-free.

```console
brew cask audit --download font-inter.rb
Error: `brew cask` is no longer a `brew` command. Use `brew <command> --cask` instead
```


- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.

```console
$ brew style --cask --fix font-inter.rb
font-inter.rb:51:3: C: FormulaAudit/Test: test do should not be empty
  test do ...
  ^^^^^^^
font-inter.rb:51:3: W: Lint/EmptyBlock: Empty block detected.
  test do ...
  ^^^^^^^

1 file inspected, 2 offenses detected
```

Would love to fix that as well.

- [x] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not already refused in [closed issues].
- [ ] Checked the cask is submitted to [the correct repo].

I do not add a new formula or cask.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-fonts/pulls
[closed issues]: https://github.com/caskroom/homebrew-fonts/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
