### PR TITLE
Gemfile.lock: specify Ruby/Bundler versions.

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -29,7 +29,7 @@ jobs:
         bundle exec ruby cask2formula commit
     - name: Clean Formula directory
       run: |
-        comm -23 --nocheck-order <(ls -1 Formula) <(ls -1 homebrew-cask/Casks/font/) | xargs -I{} sh -c 'git rm ./Formula/{} && git commit -m "Remove {}"'
+        comm -23 --nocheck-order <(ls -1 Formula) <(basename -a homebrew-cask-fonts/Casks/font/*/*) | xargs -I{} sh -c 'git rm ./Formula/{} && git commit -m "Remove {}"'
     - name: Publish to GitHub
       if: github.event_name != 'pull_request'
       env:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -16,6 +16,8 @@ jobs:
         persist-credentials: false
     - name: Set up Ruby 3
       uses: ruby/setup-ruby@v1
+      with:
+        bundler-cache: true
     - name: Configure git
       run: |
         git config user.email 'ta2gch@gmail.com'
@@ -23,8 +25,6 @@ jobs:
     - name: Convert and commit
       run: |
         git submodule update --init --remote
-        gem install bundler
-        bundle install --jobs 4 --retry 3 --without development
         bundle exec ruby cask2formula convert
         bundle exec ruby cask2formula commit
     - name: Clean Formula directory

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,5 +9,8 @@ PLATFORMS
 DEPENDENCIES
   parslet
 
+RUBY VERSION
+   ruby 3.3.1p55
+
 BUNDLED WITH
-   2.3.10
+   2.5.9

--- a/cask2formula
+++ b/cask2formula
@@ -164,6 +164,7 @@ end
 
 class CaskConverter
     def convert
+      FileUtils.mkdir_p("Formula")
       ignores = IO.readlines('.caskignore', chomp: true)
       transform = CaskTransform.new(true)
       parser = CaskParser.new

--- a/cask2formula
+++ b/cask2formula
@@ -189,7 +189,9 @@ class CaskConverter
     def commit
       `git diff --name-only; git ls-files --others --exclude-standard`.split(/\s+/).each do |file|
           if file != "homebrew-cask-fonts" then
-            remote_source = "https://github.com/homebrew/#{file.sub(/Formula/, "homebrew-cask-fonts/blob/master/Casks")}"
+            shard_letter = File.basename(file).delete_prefix("font-")[0]
+            remote_dir = "homebrew-cask/blob/master/Casks/font/font-#{shard_letter}"
+            remote_source = "https://github.com/Homebrew/#{file.sub(/Formula/, remote_dir)}"
             commit_id = `git -C homebrew-cask-fonts log -n 1 --pretty=format:%H -- #{file.sub(/Formula/, 'Casks')}`
             system 'git', 'add', file
             system 'git', 'commit', '-m', "import #{remote_source} from #{commit_id}"


### PR DESCRIPTION
This should avoid errors when bundling.

# Do not merge until CI is 🟢 