### PR TITLE
generate-linux-fonts.rb: drop sha256 stanza for no_check value

### DIFF
--- a/cmd/generate-linux-fonts.rb
+++ b/cmd/generate-linux-fonts.rb
@@ -90,9 +90,7 @@ module Homebrew
     return "" if value.nil?
 
     if stanza == :sha256 && value == "no_check"
-      <<-EOS
-  #{stanza} :#{value}
-      EOS
+      "" # Drop `sha256` stanza in formula altogether
     elsif [:url, :head].include?(stanza)
       <<-EOS
   #{stanza} #{format_url(value, args)}


### PR DESCRIPTION
Drops `sha256` stanza for no_check value instead of passing it through which probably causes #54

Fixes #54 