### PR TITLE
Generate `replacement` field for disabled/deprecated fonts

### DIFF
--- a/cmd/generate-linux-fonts.rb
+++ b/cmd/generate-linux-fonts.rb
@@ -183,9 +183,15 @@ module Homebrew
         "\"#{cask["disable_reason"]}\""
       end
 
+      replacement = if cask["disable_replacement"]
+        ", replacement: \"#{cask["disable_replacement"]}\""
+      else
+        ""
+      end
+
       formula += <<-EOS
 
-  disable! "#{cask["disable_date"]}", because: #{reason}
+  disable! "#{cask["disable_date"]}", because: #{reason}#{replacement}
       EOS
     elsif cask["deprecation_date"].present?
       reason = if !cask["deprecation_reason"].match?(" ")
@@ -194,9 +200,15 @@ module Homebrew
         "\"#{cask["deprecation_reason"]}\""
       end
 
+      replacement = if cask["deprecation_replacement"]
+        ", replacement: \"#{cask["deprecation_replacement"]}\""
+      else
+        ""
+      end
+
       formula += <<-EOS
 
-  deprecate! "#{cask["deprecation_date"]}", because: :#{cask["deprecation_reason"]}
+  deprecate! "#{cask["deprecation_date"]}", because: #{reason}#{replacement}
       EOS
     end
 


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not already refused in [closed issues].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-fonts/pulls
[closed issues]: https://github.com/caskroom/homebrew-fonts/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256

---
Deprecated fonts may have `replacement` field too (see [`font-iosevka-comfy`](https://github.com/Homebrew/homebrew-cask/blob/a8d94e5ddf727c81d455e5b97d6c8df88b6d272e/Casks/font/font-i/font-iosevka-comfy.rb#L9))